### PR TITLE
add files

### DIFF
--- a/kubernetes/ansible/inventory.ini
+++ b/kubernetes/ansible/inventory.ini
@@ -1,0 +1,6 @@
+[master]
+k8s-0 ansible_host=178.154.220.232
+
+[workers]
+k8s-1 ansible_host=84.201.172.134
+k8s-2 ansible_host=178.154.201.16

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -1,18 +1,32 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
     spec:
       containers:
-      - image: mongo
+      - image: mongo:3.2
         name: mongo
+        volumeMounts:
+        - name: mongo-persistent-storage
+          mountPath: /data/db
+      volumes:
+      - name: mongo-persistent-storage
+        emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -1,18 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
     spec:
       containers:
       - image: xxxandr84/post
         name: post
+        env:
+        - name: POST_DATABASE_HOST
+          value: post-db

--- a/kubernetes/reddit/post-mongodb-service.yml
+++ b/kubernetes/reddit/post-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -1,18 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  name: ui-deployment
-spec:
-  replicas: 1
+metadata: # Блок метаданных деплоя
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec: # Блок спецификации деплоя
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
-  template:
+      app: reddit
+      component: ui
+  template: # Блок описания POD-ов
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
-      - image: xxxandr84/ui
+      - image: xxxandr84/ui # Не забудьте подставить свой образ
         name: ui

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+  - nodePort: 32093
+    port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: ui

--- a/kubernetes/reddit_/ post-deployment.yml
+++ b/kubernetes/reddit_/ post-deployment.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: post-deployment
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: post
@@ -14,5 +14,5 @@ spec:
         app: post
     spec:
       containers:
-      - image: chromko/post
+      - image: xxxandr84/post
         name: post

--- a/kubernetes/reddit_/comment-deployment.yml
+++ b/kubernetes/reddit_/comment-deployment.yml
@@ -7,7 +7,7 @@ metadata:
     app: reddit
     component: comment
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: reddit

--- a/kubernetes/reddit_/mongo-deployment.yml
+++ b/kubernetes/reddit_/mongo-deployment.yml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo-deployment
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: mongo
+  template:
+    metadata:
+      name: mongo
+      labels:
+        app: mongo
+    spec:
+      containers:
+      - image: mongo
+        name: mongo

--- a/kubernetes/reddit_/mongodb-service.yml
+++ b/kubernetes/reddit_/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit_/post-deployment.yml
+++ b/kubernetes/reddit_/post-deployment.yml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: post-deployment
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: post
+  template:
+    metadata:
+      name: post
+      labels:
+        app: post
+    spec:
+      containers:
+      - image: xxxandr84/post
+        name: post

--- a/kubernetes/reddit_/ui-deployment.yml
+++ b/kubernetes/reddit_/ui-deployment.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: reddit
+      component: ui
+  template:
+    metadata:
+      name: ui-pod
+      labels:
+        app: reddit
+        component: ui
+    spec:
+      containers:
+      - image: xxxandr84/ui
+        name: ui
+        env:
+        - name: ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace


### PR DESCRIPTION
xandr@devops:~/otus7/XXXandr84_infra/kubernetes$ cd reddit
xandr@devops:~/otus7/XXXandr84_infra/kubernetes/reddit$ kubectl apply -f ui-deployment.yml
deployment.apps/ui created
xandr@devops:~/otus7/XXXandr84_infra/kubernetes/reddit$ kubectl get deployment
NAME   READY   UP-TO-DATE   AVAILABLE   AGE
ui     3/3     3            3           23s
xandr@devops:~/otus7/XXXandr84_infra/kubernetes/reddit$ kubectl get pods --selector comment=ui
No resources found in default namespace.
xandr@devops:~/otus7/XXXandr84_infra/kubernetes/reddit$ kubectl get pods --selector component=ui
NAME                  READY   STATUS    RESTARTS   AGE
ui-866685dc66-7hnwt   1/1     Running   0          94s
ui-866685dc66-g5fkt   1/1     Running   0          94s
ui-866685dc66-glvf8   1/1     Running   0          94s
^Cxandr@devops:~/otus7/XXXandr84_infra/kubernetes/reddit$ kubectl port-forward ui-866685dc66-7hnwt 8080:9292
Forwarding from 127.0.0.1:8080 -> 9292
Forwarding from [::1]:8080 -> 9292
Handling connection for 8080
Handling connection for 8080
E0228 08:19:10.905415 3231237 portforward.go:394] error copying from local connection to remote stream: read tcp4 127.0.0.1:8080->127.0.0.1:47506: read: connection reset by peer
E0228 08:19:10.905415 3231237 portforward.go:394] error copying from local connection to remote stream: read tcp4 127.0.0.1:8080->127.0.0.1:47500: read: connection reset by peer
Handling connection for 8080






NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
service/comment      ClusterIP   10.107.199.104   <none>        9292/TCP         8h
service/comment-db   ClusterIP   10.105.85.197    <none>        27017/TCP        7h38m
service/kubernetes   ClusterIP   10.96.0.1        <none>        443/TCP          8d
service/mongodb      ClusterIP   10.97.2.85       <none>        27017/TCP        8h
service/post         ClusterIP   10.104.223.243   <none>        5000/TCP         7h45m
service/post-db      ClusterIP   10.103.164.139   <none>        27017/TCP        13m
service/ui           NodePort    10.109.97.186    <none>        9292:32092/TCP   3m26s

NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/comment   1/1     1            1           8h
deployment.apps/mongo     1/1     1            1           8h
deployment.apps/post      3/3     3            3           7h57m
deployment.apps/ui        3/3     3            3           8h

NAME                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/comment-55c5d6cfdd   1         1         1       7h20m
replicaset.apps/comment-7456f5dc94   0         0         0       8h
replicaset.apps/comment-7db6c6c48    0         0         0       7h11m
replicaset.apps/mongo-7c7656f58c     0         0         0       8h
replicaset.apps/mongo-7f84885df5     1         1         1       19m
replicaset.apps/post-57b5bb8c66      3         3         3       3m26s
replicaset.apps/post-f58898cb4       0         0         0       7h57m
replicaset.apps/ui-866685dc66        3         3         3       8h
xandr@devops:~/otus7/XXXandr84_infra$ kubectl port-forward pod/ui-866685dc66-z728d 8080:9292Forwarding from 127.0.0.1:8080 -> 9292
Forwarding from [::1]:8080 -> 9292
Handling connection for 8080
Handling connection for 8080















xandr@devops:~/otus7/XXXandr84_infra$ minikube service ui
|-----------|------|-------------|---------------------------|
| NAMESPACE | NAME | TARGET PORT |            URL            |
|-----------|------|-------------|---------------------------|
| default   | ui   |        9292 | http://192.168.49.2:32092 |
|-----------|------|-------------|---------------------------|
* Opening service default/ui in default browser…



 minikube service list
|xandr@devops:~/otus7/XXXandr84_infra$ minikube service list
|----------------------|---------------------------|--------------|---------------------------|
|      NAMESPACE       |           NAME            | TARGET PORT  |            URL            |
|----------------------|---------------------------|--------------|---------------------------|
| default              | comment                   | No node port |                           |
| default              | comment-db                | No node port |                           |
| default              | kubernetes                | No node port |                           |
| default              | mongodb                   | No node port |                           |
| default              | post                      | No node port |                           |
| default              | post-db                   | No node port |                           |
| default              | ui                        |         9292 | http://192.168.49.2:32092 |
| kube-system          | kube-dns                  | No node port |                           |
| kubernetes-dashboard | dashboard-metrics-scraper | No node port |                           |
| kubernetes-dashboard | kubernetes-dashboard      | No node port |                           |
|----------------------|---------------------------|--------------|---------------------------|
[xandr@devops](mailto:xandr@devops):~/otus7/XXXandr84_infra$



xandr@devops:~/otus7/XXXandr84_infra$ minikube addons list
|-----------------------------|----------|--------------|--------------------------------|
|         ADDON NAME          | PROFILE  |    STATUS    |           MAINTAINER           |
|-----------------------------|----------|--------------|--------------------------------|
| ambassador                  | minikube | disabled     | 3rd party (Ambassador)         |
| auto-pause                  | minikube | disabled     | minikube                       |
| cloud-spanner               | minikube | disabled     | Google                         |
| csi-hostpath-driver         | minikube | disabled     | Kubernetes                     |
| dashboard                   | minikube | enabled ✅   | Kubernetes                     |
| default-storageclass        | minikube | enabled ✅   | Kubernetes                     |
| efk                         | minikube | disabled     | 3rd party (Elastic)            |
| freshpod                    | minikube | disabled     | Google                         |
| gcp-auth                    | minikube | disabled     | Google                         |
| gvisor                      | minikube | disabled     | minikube                       |
| headlamp                    | minikube | disabled     | 3rd party (kinvolk.io)         |
| helm-tiller                 | minikube | disabled     | 3rd party (Helm)               |
| inaccel                     | minikube | disabled     | 3rd party (InAccel             |
|                             |          |              | [info@inaccel.com])            |
| ingress                     | minikube | disabled     | Kubernetes                     |
| ingress-dns                 | minikube | disabled     | minikube                       |
| inspektor-gadget            | minikube | disabled     | 3rd party                      |
|                             |          |              | (inspektor-gadget.io)          |
| istio                       | minikube | disabled     | 3rd party (Istio)              |
| istio-provisioner           | minikube | disabled     | 3rd party (Istio)              |
| kong                        | minikube | disabled     | 3rd party (Kong HQ)            |
| kubeflow                    | minikube | disabled     | 3rd party                      |
| kubevirt                    | minikube | disabled     | 3rd party (KubeVirt)           |
| logviewer                   | minikube | disabled     | 3rd party (unknown)            |
| metallb                     | minikube | disabled     | 3rd party (MetalLB)            |
| metrics-server              | minikube | disabled     | Kubernetes                     |
| nvidia-device-plugin        | minikube | disabled     | 3rd party (NVIDIA)             |
| nvidia-driver-installer     | minikube | disabled     | 3rd party (Nvidia)             |
| nvidia-gpu-device-plugin    | minikube | disabled     | 3rd party (Nvidia)             |
| olm                         | minikube | disabled     | 3rd party (Operator Framework) |
| pod-security-policy         | minikube | disabled     | 3rd party (unknown)            |
| portainer                   | minikube | disabled     | 3rd party (Portainer.io)       |
| registry                    | minikube | disabled     | minikube                       |
| registry-aliases            | minikube | disabled     | 3rd party (unknown)            |
| registry-creds              | minikube | disabled     | 3rd party (UPMC Enterprises)   |
| storage-provisioner         | minikube | enabled ✅   | minikube                       |
| storage-provisioner-gluster | minikube | disabled     | 3rd party (Gluster)            |
| storage-provisioner-rancher | minikube | disabled     | 3rd party (Rancher)            |
| volumesnapshots             | minikube | disabled     | Kubernetes                     |
|-----------------------------|----------|--------------|--------------------------------|
[xandr@devops](mailto:xandr@devops):~/otus7/XXXandr84_infra$

minikube dashboard

* Verifying dashboard health ...
* Launching proxy ...
* Verifying proxy health ...
* Opening http://127.0.0.1:40537/api/v1/namespaces/kubernetes-dashboard/services/http:kubernetes-dashboard:/proxy/ in your default browser…


xandr@devops:~/otus7/XXXandr84_infra$ kubectl apply -n dev -f kubernetes/reddit/
deployment.apps/comment unchanged
service/comment-db unchanged
service/comment unchanged
namespace/dev unchanged
deployment.apps/mongo unchanged
service/mongodb unchanged
deployment.apps/post unchanged
service/post-db unchanged
service/post unchanged
deployment.apps/ui unchanged
service/ui created
xandr@devops:~/otus7/XXXandr84_infra$ minikube service ui -n dev
|-----------|------|-------------|---------------------------|
| NAMESPACE | NAME | TARGET PORT |            URL            |
|-----------|------|-------------|---------------------------|
| dev       | ui   |        9292 | http://192.168.49.2:32093 |
|-----------|------|-------------|---------------------------|
* Opening service dev/ui in default browser...
xandr@devops:~/otus7/XXXandr84_infra$


Yandex Cloud Managed Service for kubernetes
Создал кластер и группу хостов. 

kubectl get nodes -o wide


NAME                        STATUS   ROLES    AGE     VERSION    INTERNAL-IP   EXTERNAL-IP       OS-IMAGE             KERNEL-VERSION     CONTAINER-RUNTIME
cl16mhlpc65fktupj9es-apic   Ready    <none>   9m36s   v1.19.10   10.128.0.25   178.154.254.139   Ubuntu 20.04.2 LTS   5.4.0-74-generic   docker://24.0.7
cl16mhlpc65fktupj9es-obuc   Ready    <none>   9m27s   v1.19.10   10.128.0.12   84.201.130.18     Ubuntu 20.04.2 LTS   5.4.0-74-generic   docker://24.0.7

 - [ ] Задание со *

## В процессе сделано:
 - Пункт 1
 - Пункт 2

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist
 - [ ] Выставил label с номером домашнего задания
 - [ ] Выставил label с темой домашнего задания
[k2.odt](https://github.com/Otus-DevOps-2023-09/XXXandr84_infra/files/14438014/k2.odt)
